### PR TITLE
Setting the right timestamp format.

### DIFF
--- a/lib/OpenGuides/JSON.pm
+++ b/lib/OpenGuides/JSON.pm
@@ -101,7 +101,7 @@ sub emit_json {
     $data->{timestamp} = $node_data{last_modified};
 
     # Make a Time::Piece object.
-    my $timestamp_fmt = $Wiki::Toolkit;
+    my $timestamp_fmt = $Wiki::Toolkit::Store::Database::timestamp_fmt;
 
     if ( $data->{timestamp} ) {
         my $time = Time::Piece->strptime( $data->{timestamp}, $timestamp_fmt );


### PR DESCRIPTION
So the conversion can work instead of returning the epoch start.
This fixes issue #5.
http://dev.croydon.randomness.org.uk/wiki.cgi?id=Sara%27s_Diner%2C_65_Church_Street;format=json to see it working.
