### PR TITLE
Add the external css class to map and web links in the metadata.

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,8 @@ More detailed changelogs can be found at
           deprecation warnings. 
         Node JSON output now contains image information.
         Node JSON output now includes raw and html formatted content.
+        Add the external class to website and map links when
+          displaying them in the metadata section of a node. 
 
 0.72    28 June 2013
         Fix the date in json output. Fixes #5

--- a/lib/OpenGuides/Template.pm
+++ b/lib/OpenGuides/Template.pm
@@ -380,7 +380,7 @@ sub extract_metadata_vars {
         if ( length( $trunc_website ) > $maxlen ) {
             $trunc_website = substr( $trunc_website, 0, $maxlen - 3 ) . "...";
         }
-        $formatted_website_text = '<a href="' . $website . '">'
+        $formatted_website_text = '<a href="' . $website . '" class="external">'
                                   . $trunc_website . '</a>';
     }
 

--- a/t/608_bug_website_displayed.t
+++ b/t/608_bug_website_displayed.t
@@ -33,25 +33,25 @@ $config->website_link_max_chars( 20 );
 my %tt_vars = $guide->display_node( id => "South Croydon Station",
                                     return_tt_vars => 1 );
 is( $tt_vars{formatted_website_text},
-    '<a href="http://example.com/">example.com</a>',
+    '<a href="http://example.com/" class="external">example.com</a>',
     "Website correctly displayed when no need for truncation," );
 
 %tt_vars = $guide->display_node( id => "East Croydon Station",
                                     return_tt_vars => 1 );
 is( $tt_vars{formatted_website_text},
-    '<a href="http://www.example.com/foo">example.com/foo</a>',
+    '<a href="http://www.example.com/foo" class="external">example.com/foo</a>',
     "Website correctly truncated when there's a leading www" );
 
 %tt_vars = $guide->display_node( id => "West Croydon Station",
                                     return_tt_vars => 1 );
 is( $tt_vars{formatted_website_text},
-    '<a href="http://www.example.com/bar/">example.com/bar/</a>',
+    '<a href="http://www.example.com/bar/" class="external">example.com/bar/</a>',
     "Trailing slash not stripped unless it's immediately after domain name" );
 
 %tt_vars = $guide->display_node( id => "North Croydon Station",
                                     return_tt_vars => 1 );
 is( $tt_vars{formatted_website_text},
-    '<a href="http://longer.example.com/asdfasdf">longer.example.co...</a>',
+    '<a href="http://longer.example.com/asdfasdf" class="external">longer.example.co...</a>',
     "Website correctly truncated when much too long." );
 
 # Make sure website isn't truncated unnecessarily, e.g. that we don't end up
@@ -61,19 +61,19 @@ $config->website_link_max_chars( 26 );
 %tt_vars = $guide->display_node( id => "North Croydon Station",
                                  return_tt_vars => 1 );
 is( $tt_vars{formatted_website_text},
- '<a href="http://longer.example.com/asdfasdf">longer.example.com/asdf...</a>',
+ '<a href="http://longer.example.com/asdfasdf" class="external">longer.example.com/asdf...</a>',
     "Website truncated correctly when 1 character longer than allowed." );
 
 $config->website_link_max_chars( 27 );
 %tt_vars = $guide->display_node( id => "North Croydon Station",
                                  return_tt_vars => 1 );
 is( $tt_vars{formatted_website_text},
-'<a href="http://longer.example.com/asdfasdf">longer.example.com/asdfasdf</a>',
+'<a href="http://longer.example.com/asdfasdf" class="external">longer.example.com/asdfasdf</a>',
     "Website not truncated when exact length allowed." );
 
 $config->website_link_max_chars( 28 );
 %tt_vars = $guide->display_node( id => "North Croydon Station",
                                  return_tt_vars => 1 );
 is( $tt_vars{formatted_website_text},
-'<a href="http://longer.example.com/asdfasdf">longer.example.com/asdfasdf</a>',
+'<a href="http://longer.example.com/asdfasdf" class="external">longer.example.com/asdfasdf</a>',
     "Website not truncated when 1 character shorter than allowed." );

--- a/t/909_external_class_metadata.t
+++ b/t/909_external_class_metadata.t
@@ -1,0 +1,49 @@
+use strict;
+use OpenGuides;
+use OpenGuides::CGI;
+use OpenGuides::Test;
+use Test::More;
+use Cwd;
+
+eval { require DBD::SQLite; };
+if ( $@ ) {
+    my ($error) = $@ =~ /^(.*?)\n/;
+    plan skip_all =>
+        "DBD::SQLite could not be used - no database to test with. ($error)";
+}
+
+plan tests => 2;
+
+my $config = OpenGuides::Test->make_basic_config;
+my $guide = OpenGuides->new( config => $config );
+my $wiki = $guide->wiki;
+
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
+# Write out a node with a map link and external website
+OpenGuides::Test->write_data(
+                              guide         => $guide,
+                              node          => "Red Lion",
+                              address       => "High Street",
+                              latitude      => 51.4,
+                              longitude     => -0.2,
+                              locales       => "Croydon\r\nWaddon",
+                              return_output => 1,
+                              map_link      => 'http://maps.example.org/Red_Lion_Croydon',
+                              website       => 'http://example.com',
+                            );
+
+
+
+my $output = $guide->display_node(
+                                   id             => 'Red Lion',
+                                   return_output  => 1,
+                                   noheaders      => 1
+                                 );
+
+like( $output, qr#<a href="http://maps\.example\.org/Red_Lion_Croydon" class="external"#,
+         "map link has a class of external" );
+like( $output, qr#"url"><a href="http://example.com" class="external">example.com</a>#,
+         "website link has a class of external" );
+

--- a/templates/display_metadata.tt
+++ b/templates/display_metadata.tt
@@ -30,7 +30,7 @@
           [% INCLUDE custom_auto_map_link.tt %]
         [% CATCH %]
           [% IF map_link %]
-            <a href="[% map_link %]">(map of this place)</a>
+            <a href="[% map_link %]" class="external">(map of this place)</a>
           [% END %]
         [% END %]
       </li>
@@ -40,7 +40,7 @@
       [% CATCH %]
         [% IF map_link %]
           <li class="map">
-            <span class="metadata_label"><a href="[% map_link %]">Map of this place</a></span>
+            <span class="metadata_label"><a href="[% map_link %]" class="external">Map of this place</a></span>
           </li>
         [% END %]
       [% END %]


### PR DESCRIPTION
Map and website links in the metadata section of a diplayed node will now have a class to external so that guides can use css to indicate they are and external link.
This fixes #24
