### PR TITLE
Refresh the database before caching a connection handle to it

### DIFF
--- a/t/109_autocreate.t
+++ b/t/109_autocreate.t
@@ -14,15 +14,15 @@ if ( $@ ) {
 
 plan tests => 13;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 $config->custom_template_path( cwd . "/t/templates/" );
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
 my $categoriser = Wiki::Toolkit::Plugin::Categoriser->new;
 $wiki->register_plugin( plugin => $categoriser );
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Check that unwelcome characters are stripped from autocreated cats/locales.
 # Double spaces:

--- a/t/802_stylesheet.t
+++ b/t/802_stylesheet.t
@@ -18,12 +18,12 @@ if ( $@ ) {
 
 plan tests => 3;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Write a node.
 OpenGuides::Test->write_data( guide => $guide, node => "Red Lion",

--- a/t/809_recent_changes_ip_addr.t
+++ b/t/809_recent_changes_ip_addr.t
@@ -14,12 +14,12 @@ if ( $@ ) {
 
 plan tests => 10;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # First we need to make sure that the preferences are accessible
 # from the recent changes view.  Can't test this using return_tt_vars

--- a/t/900_css_category_locale_classes.t
+++ b/t/900_css_category_locale_classes.t
@@ -18,12 +18,12 @@ if ( $@ ) {
 
 plan tests => 3;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 $config->custom_template_path( cwd . "/t/templates/" );
 my $guide = OpenGuides->new( config => $config );
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Check that a node in one locale and one category has CSS classes for both.
 OpenGuides::Test->write_data(

--- a/t/901_username_in_templates.t
+++ b/t/901_username_in_templates.t
@@ -14,12 +14,12 @@ if ( $@ ) {
 
 plan tests => 2;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 $config->custom_template_path( cwd . "/t/templates/tmp/" );
 my $guide = OpenGuides->new( config => $config );
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Write a node.
 OpenGuides::Test->write_data(

--- a/t/902_node_name_from_cgi_obj.t
+++ b/t/902_node_name_from_cgi_obj.t
@@ -13,12 +13,12 @@ if ( $@ ) {
 
 plan tests => 18;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Write a node.
 OpenGuides::Test->write_data(

--- a/t/903_redirect_without_spaces.t
+++ b/t/903_redirect_without_spaces.t
@@ -13,12 +13,12 @@ if ( $@ ) {
 
 plan tests => 27;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Write a couple of nodes, one with a single-word name, one with multiple.
 OpenGuides::Test->write_data(

--- a/t/904_leaflet.t
+++ b/t/904_leaflet.t
@@ -16,13 +16,13 @@ my $thc = $@ ? 0 : 1;
 
 plan tests => 25;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 $config->static_url( "http://example.com/static" );
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Write a couple of nodes, two with legitimate geodata, another with
 # broken geodata, another with no geodata.

--- a/t/905_multiple_index.t
+++ b/t/905_multiple_index.t
@@ -19,12 +19,12 @@ if ( $@ ) {
 
 plan tests => 18;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Write some nodes.
 OpenGuides::Test->write_data(

--- a/t/907_auto_map_link.t
+++ b/t/907_auto_map_link.t
@@ -14,13 +14,13 @@ if ( $@ ) {
 
 plan tests => 10;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 $config->custom_template_path( cwd . "/t/templates/tmp/" );
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Write a couple of nodes, one with a map link and another
 # without; also with/without address

--- a/t/908_custom_node_location_search.t
+++ b/t/908_custom_node_location_search.t
@@ -14,13 +14,13 @@ if ( $@ ) {
 
 plan tests => 3;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 $config->custom_template_path( cwd . "/t/templates/tmp/" );
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Write a couple of nodes, one with a map link and another
 # without; also with/without address

--- a/t/909_external_class_metadata.t
+++ b/t/909_external_class_metadata.t
@@ -14,12 +14,12 @@ if ( $@ ) {
 
 plan tests => 2;
 
+# Clear out the database from any previous runs.
+OpenGuides::Test::refresh_db();
+
 my $config = OpenGuides::Test->make_basic_config;
 my $guide = OpenGuides->new( config => $config );
 my $wiki = $guide->wiki;
-
-# Clear out the database from any previous runs.
-OpenGuides::Test::refresh_db();
 
 # Write out a node with a map link and external website
 OpenGuides::Test->write_data(


### PR DESCRIPTION
OpenGuides->new() caches a connection to the SQLite database.  When
OpenGuides::Test::refresh_db() is called, it removes the database file
and reconnects to it. If that happens after OpenGuides->new(), the cached
handle becomes read-only as of SQLite 3.8.3. From its changelog:

 Add SQLITE_READONLY_DBMOVED error code, returned at the beginning of
 a transaction, to indicate that the underlying database file has been
 renamed or moved out from under SQLite.

This causes test failures with error messages like

Unhandled error: [DBD::SQLite::st execute failed: attempt to write a readonly database at /usr/share/perl5/Wiki/Toolkit/Store/Database.pm line 567.
] at /usr/share/perl5/Wiki/Toolkit.pm line 849.

Moving the refresh_db() call earlier fixes these failures.
