### PR TITLE
Remove the @RSS macro.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -350,7 +350,6 @@ $build->requires({
     'Wiki::Toolkit::Plugin::Diff'         => 0,
     'Wiki::Toolkit::Plugin::JSON'         => '0.05',
     'Wiki::Toolkit::Plugin::Locator::Grid'=> 0,
-    'Wiki::Toolkit::Plugin::RSS::Reader'  => 0,
     'Class::Accessor'                     => 0,
     'Config::Tiny'                        => 0,
     'Data::Dumper'                        => 0,


### PR DESCRIPTION
This fixes #33. The macro has issues with displaying stuff and is not used by anyone in anger.

The fact that no tests need to be removed to remove this macro suggests how much people care about it.