### PR TITLE
Trim leading/trailing whitespace from the fax field.

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,11 @@
 More detailed changelogs can be found at
 <http://github.com/OpenGuides/OpenGuides>
 
+0.81
+        Trim leading/trailing whitespace from the fax field (so those of us
+          using this field to store the Twitter username don't get broken
+          links).
+
 0.80    07 June 2015
         Fix calling CGI:param in a list context #85
 

--- a/lib/OpenGuides/Template.pm
+++ b/lib/OpenGuides/Template.pm
@@ -469,6 +469,12 @@ sub extract_metadata_vars {
             $vars{$var} = $q->param($var);
         }
 
+        # Trim leading and trailing whitespace from the fax field - some
+        # guides use this to store the Twitter username, so whitespace will
+        # mess things up when this is turned into a URL.
+        $vars{fax} =~ s/^\s+//g;
+        $vars{fax} =~ s/\s+$//g;
+
         my $geo_handler = $config->geo_handler;
         if ( $geo_handler == 1 ) {
             require Geo::Coordinates::OSGB;

--- a/t/602_bug_trailing_whitespace.t
+++ b/t/602_bug_trailing_whitespace.t
@@ -13,7 +13,7 @@ if ( $@ ) {
     plan skip_all => "DBD::SQLite could not be used - no database to test with ($error)";
 }
 
-plan tests => 8;
+plan tests => 9;
 
 # Clear out the database from any previous runs.
     OpenGuides::Test::refresh_db();
@@ -36,8 +36,6 @@ my $guide = OpenGuides->new( config => $config );
     is( $metadata_vars{os_x}, "123456",
         "leading and trailing spaces stripped from os_x when processed" );
     is( $metadata_vars{os_y}, "654321", "...and os_y" );
-
-
 
     $config->geo_handler( 2 );
     $q = CGI->new( "" );
@@ -78,6 +76,7 @@ OpenGuides::Test->write_data(
                               node  => "A Node",
                               categories => " Food \r\n Live Music ",
                               locales    => " Hammersmith \r\n Fulham ",
+                              fax => " 567890 ",
 );
 my %node = $guide->wiki->retrieve_node( "A Node" );
 my %data = %{ $node{metadata} };
@@ -86,3 +85,5 @@ is_deeply( \@cats, [ "Food", "Live Music" ],
     "leading and trailing spaces stripped from all categories when stored" );
 my @locs = sort @{ $data{locale} || [] };
 is_deeply( \@locs, [ "Fulham", "Hammersmith" ], "...and all locales" );
+my $fax = $data{fax}[0];
+is( $fax, "567890", "...and fax field" );


### PR DESCRIPTION
Some of us are using the fax field to store Twitter usernames (I KNOW THIS IS WRONG). Stripping leading/trailing whitespace means we don't get broken links, and won't affect people using this field for an actual fax number.