### PR TITLE
Set sudo to false for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ before_install: cpanm --quiet --notest Config::Tiny Geo::HelmertTransform Test::
 script: perl Build.PL && ./Build build && cover -test -ignore Build.pm -report coveralls
 notifications:
   irc: "irc.perl.org#openguides-notices"
+sudo: false


### PR DESCRIPTION
Set sudo to false for travis so that we can use their container
infrastructure.
http://docs.travis-ci.com/user/migrating-from-legacy/