### PR TITLE
Use environment variables to configure OpenGuides

### DIFF
--- a/lib/OpenGuides/Config.pm
+++ b/lib/OpenGuides/Config.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use vars qw( $VERSION );
-$VERSION = '0.10';
+$VERSION = '0.11';
 
 use Carp qw( croak );
 use Config::Tiny;
@@ -52,7 +52,8 @@ This documentation is probably only useful to OpenGuides developers.
 
   my $config = OpenGuides::Config->new( file => "wiki.conf" );
 
-Initialises itself from the config file specified.  Variables which
+Initialises itself from the config file specified and environment
+variables of the form OPENGUIDES_CONFIG_READ_ONLY.  Variables which
 are not set in that file, and which have sensible defaults, will be
 initialised as described below in ACCESSORS; others will be given a
 value of C<undef>.
@@ -151,7 +152,14 @@ sub _init {
             warn "Don't know what to do with variable '$var'";
         }
     }
-
+    # Override config from file or defaults if an environment variable
+    # is set for a variable. e.g OPENGUIDES_CONFIG_read_only
+    foreach my $var ( @variables ) {
+       my $envvar = "OPENGUIDES_CONFIG_" . uc ( $var );
+       if ( exists $ENV{$envvar} ) {
+           $self->$var ( $ENV{$envvar} );
+       }
+    }
     # And the questions.
     # Don't forget to add to INSTALL when changing these.
     my %questions = (
@@ -387,7 +395,7 @@ The OpenGuides Project (openguides-dev@lists.openguides.org)
 
 =head1 COPYRIGHT
 
-     Copyright (C) 2004-2013 The OpenGuides Project.  All Rights Reserved.
+     Copyright (C) 2004-2020 The OpenGuides Project.  All Rights Reserved.
 
 The OpenGuides distribution is free software; you can redistribute it
 and/or modify it under the same terms as Perl itself.

--- a/t/110_config_via_envvar.t
+++ b/t/110_config_via_envvar.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+BEGIN {
+  # a default config option
+  $ENV{OPENGUIDES_CONFIG_SITE_NAME} = 'my test site';
+  # a non default config option
+  $ENV{OPENGUIDES_CONFIG_CONTACT_EMAIL} = 'testsite@example.com';
+}
+
+use Test::More;
+use OpenGuides;
+use OpenGuides::Test;
+
+plan tests => 2;
+my $config = OpenGuides::Test->make_basic_config;
+my $guide = OpenGuides->new(config => $config);
+
+my $output = $guide->display_about(return_output => 1,
+                                format        => "opensearch"
+                               );
+
+like( $output, qr|OpenSearchDescription.*<Tags>my test site</Tags>.*|ms,
+    "OpenSearch about text is displayed, including the site name which overrides a default config value with an environment variable");
+like( $output, qr|OpenSearchDescription.*<Contact>testsite\@example.com</Contact>|ms,
+    "OpenSearch about text is displayed, including the contact email from environment variables which does not have a default value");


### PR DESCRIPTION
Enable configuration of OpenGuides via environment variables which look
like OPENGUIDES_CONFIG_read_only=1. This makes running OpenGuides in a
container easier.

Environment variables override all other configuration.