### PR TITLE
Update to Wiki::Toolkit 0.86

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -344,7 +344,7 @@ $build->requires({
     'CGI'                                 => '4.08',  # use multi_param
     'CGI::Carp'                           => 0,
     'CGI::Cookie'                         => 0,
-    'Wiki::Toolkit'                       => '0.84',
+    'Wiki::Toolkit'                       => '0.86',
     'Wiki::Toolkit::Feed::Atom'           => 0,
     'Wiki::Toolkit::Feed::RSS'            => 0,
     'Wiki::Toolkit::Formatter::UseMod'    => 0.25, # for escape_url_commas


### PR DESCRIPTION
Wiki::Toolkit 0.86 fixes some issues seen when you use modern versions of
MySQl. See https://github.com/OpenGuides/Wiki-Toolkit/blob/65451fa348b6d220f15f52a0dd932f8296b75d08/Changes#L1