### PR TITLE
Ignore docker/db in git and docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Makefile.PL
 OpenGuides-*
 cover_db/
 *~
+docker/db


### PR DESCRIPTION
This directory is where docker-compose keeps database data. This doesnt need to
be checked in or sent to the docker daemon. We make the dockerignore the same
as the gitignore for simplicity.